### PR TITLE
Create bigrams that include spaces

### DIFF
--- a/PCA/PCA.fsx
+++ b/PCA/PCA.fsx
@@ -50,7 +50,7 @@ let alphabet = " abcdefghijklmnopqrstuvwxyz"
 let letterPairs =
     [| for a in alphabet do 
         for b in alphabet do
-            if a <> ' ' && b <> ' ' then yield [|a; b|] |]
+            if a <> ' ' || b <> ' ' then yield [|a; b|] |]
 
 // Extract bigram counts from a specific book
 let bookBigrams filename =


### PR DESCRIPTION
Your blog post states that this is intended to create bigrams of all letter/space combinations besides two consecutive spaces. However, your use of `&&` means your bigrams never include spaces.

This patch corrects that.
